### PR TITLE
Add events for other plugins to interact with player data saving and injection

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: PerWorldPlayer
 main: BlockHorizons\PerWorldPlayer\Loader
 api: 3.11.1
-version: 0.2.0
+version: 0.3.0
 
 permissions:
   per-world-player.bypass:

--- a/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataEvent.php
+++ b/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BlockHorizons\PerWorldPlayer\events;
+
+use BlockHorizons\PerWorldPlayer\world\data\PlayerWorldData;
+use BlockHorizons\PerWorldPlayer\world\WorldInstance;
+use pocketmine\event\Event;
+use pocketmine\Player;
+
+abstract class PerWorldPlayerDataEvent extends Event{
+	/** @var Player */
+	private $player;
+
+	/** @var WorldInstance */
+	private $worldInstance;
+
+	/** @var PlayerWorldData */
+	private $playerWorldData;
+
+	public function __construct(Player $player, WorldInstance $worldInstance, PlayerWorldData $playerWorldData){
+		$this->player = $player;
+		$this->worldInstance = $worldInstance;
+		$this->playerWorldData = $playerWorldData;
+	}
+
+	public function getPlayer() : Player{
+		return $this->player;
+	}
+
+	public function getWorldInstance() : WorldInstance{
+		return $this->worldInstance;
+	}
+
+	public function getPlayerWorldData() : PlayerWorldData{
+		return $this->playerWorldData;
+	}
+
+	public function setPlayerWorldData(PlayerWorldData $playerWorldData) : void{
+		$this->playerWorldData = $playerWorldData;
+	}
+}

--- a/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataInjectEvent.php
+++ b/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataInjectEvent.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace BlockHorizons\PerWorldPlayer\events;
+
+use pocketmine\event\Cancellable;
+
+class PerWorldPlayerDataInjectEvent extends PerWorldPlayerDataEvent implements Cancellable{
+
+}

--- a/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataSaveEvent.php
+++ b/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataSaveEvent.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace BlockHorizons\PerWorldPlayer\events;
+
+use BlockHorizons\PerWorldPlayer\world\data\PlayerWorldData;
+use BlockHorizons\PerWorldPlayer\world\WorldInstance;
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+
+class PerWorldPlayerDataSaveEvent extends PerWorldPlayerDataEvent implements Cancellable{
+	/** @var bool */
+	private $quit;
+
+	public function __construct(Player $player, WorldInstance $worldInstance, PlayerWorldData $playerWorldData, bool $quit){
+		parent::__construct($player, $worldInstance, $playerWorldData);
+		$this->quit = $quit;
+	}
+
+	public function hasQuit() : bool{
+		return $this->quit;
+	}
+}

--- a/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataSaveEvent.php
+++ b/src/BlockHorizons/PerWorldPlayer/events/PerWorldPlayerDataSaveEvent.php
@@ -9,15 +9,20 @@ use pocketmine\event\Cancellable;
 use pocketmine\Player;
 
 class PerWorldPlayerDataSaveEvent extends PerWorldPlayerDataEvent implements Cancellable{
-	/** @var bool */
-	private $quit;
 
-	public function __construct(Player $player, WorldInstance $worldInstance, PlayerWorldData $playerWorldData, bool $quit){
+	public const CAUSE_WORLD_CHANGE = 0;
+	public const CAUSE_PLAYER_QUIT = 1;
+	public const CAUSE_CUSTOM = 2;
+
+	/** @var int */
+	private $cause;
+
+	public function __construct(Player $player, WorldInstance $worldInstance, PlayerWorldData $playerWorldData, int $cause){
 		parent::__construct($player, $worldInstance, $playerWorldData);
-		$this->quit = $quit;
+		$this->cause = $cause;
 	}
 
-	public function hasQuit() : bool{
-		return $this->quit;
+	public function getCause() : int{
+		return $this->cause;
 	}
 }

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
@@ -10,6 +10,7 @@ use BlockHorizons\PerWorldPlayer\world\database\WorldDatabase;
 use pocketmine\level\Level;
 use pocketmine\Player;
 use BlockHorizons\PerWorldPlayer\events\PerWorldPlayerDataInjectEvent;
+use BlockHorizons\PerWorldPlayer\events\PerWorldPlayerDataSaveEvent;
 
 final class WorldInstance{
 
@@ -72,8 +73,13 @@ final class WorldInstance{
 	}
 
 	public function save(Player $player, PlayerWorldData $data, bool $force = false, bool $quit = false) : void{
-		if($force || !$player->hasPermission("per-world-player.bypass")){
-			$this->database->save($this, $player, $data, $quit);
+		$ev = new PerWorldPlayerDataSaveEvent($player, $this, $data, $quit);
+		if(!$force && $player->hasPermission("per-world-player.bypass")){
+			$ev->setCancelled();
+		}
+		$ev->call();
+		if(!$ev->isCancelled()){
+			$this->database->save($this, $player, $ev->getPlayerWorldData(), $quit);
 		}
 	}
 }

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
@@ -80,6 +80,8 @@ final class WorldInstance{
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$this->database->save($this, $player, $ev->getPlayerWorldData(), $quit);
+		}else{
+			$player->getServer()->getLogger()->debug("Player world data save cancelled for player {$player->getName()} in world {$this->getName()}.");
 		}
 	}
 }

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
@@ -72,11 +72,11 @@ final class WorldInstance{
 
 	public function onPlayerExit(Player $player, ?WorldInstance $to_world = null, bool $quit = false) : void{
 		if($to_world === null || !self::haveSameBundles($this, $to_world)){ //TODO: currently plugins cannot bypass this
-			$this->save($player, PlayerWorldData::fromPlayer($player), false, $quit ? PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT : PerWorldPlayerDataSaveEvent::CAUSE_WORLD_CHANGE);
+			$this->save($player, PlayerWorldData::fromPlayer($player), $quit ? PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT : PerWorldPlayerDataSaveEvent::CAUSE_WORLD_CHANGE);
 		}
 	}
 
-	public function save(Player $player, PlayerWorldData $data, bool $force = false, int $cause = PerWorldPlayerDataSaveEvent::CAUSE_CUSTOM) : void{
+	public function save(Player $player, PlayerWorldData $data, int $cause = PerWorldPlayerDataSaveEvent::CAUSE_CUSTOM, bool $force = false) : void{
 		$ev = new PerWorldPlayerDataSaveEvent($player, $this, $data, $cause);
 		if(!$force && $player->hasPermission("per-world-player.bypass")){
 			$ev->setCancelled();

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldInstance.php
@@ -68,18 +68,18 @@ final class WorldInstance{
 
 	public function onPlayerExit(Player $player, ?WorldInstance $to_world = null, bool $quit = false) : void{
 		if($to_world === null || !self::haveSameBundles($this, $to_world)){ //TODO: currently plugins cannot bypass this
-			$this->save($player, PlayerWorldData::fromPlayer($player), false, $quit);
+			$this->save($player, PlayerWorldData::fromPlayer($player), false, $quit ? PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT : PerWorldPlayerDataSaveEvent::CAUSE_WORLD_CHANGE);
 		}
 	}
 
-	public function save(Player $player, PlayerWorldData $data, bool $force = false, bool $quit = false) : void{
-		$ev = new PerWorldPlayerDataSaveEvent($player, $this, $data, $quit);
+	public function save(Player $player, PlayerWorldData $data, bool $force = false, int $cause = PerWorldPlayerDataSaveEvent::CAUSE_CUSTOM) : void{
+		$ev = new PerWorldPlayerDataSaveEvent($player, $this, $data, $cause);
 		if(!$force && $player->hasPermission("per-world-player.bypass")){
 			$ev->setCancelled();
 		}
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->database->save($this, $player, $ev->getPlayerWorldData(), $quit);
+			$this->database->save($this, $player, $ev->getPlayerWorldData(), $cause);
 		}else{
 			$player->getServer()->getLogger()->debug("Player world data save cancelled for player {$player->getName()} in world {$this->getName()}.");
 		}

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BlockHorizons\PerWorldPlayer\world;
 
+use BlockHorizons\PerWorldPlayer\events\PerWorldPlayerDataSaveEvent;
 use BlockHorizons\PerWorldPlayer\Loader;
 use BlockHorizons\PerWorldPlayer\player\PlayerManager;
 use BlockHorizons\PerWorldPlayer\world\bundle\BundleManager;
@@ -44,7 +45,7 @@ final class WorldManager{
 		foreach(Server::getInstance()->getLevels() as $world){
 			$instance = $this->get($world);
 			foreach($world->getPlayers() as $player){
-				$instance->save($player, PlayerWorldData::fromPlayer($player));
+				$instance->save($player, PlayerWorldData::fromPlayer($player), false, PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT);
 			}
 		}
 

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
@@ -49,7 +49,7 @@ final class WorldManager{
 		foreach(Server::getInstance()->getLevels() as $world){
 			$instance = $this->get($world);
 			foreach($world->getPlayers() as $player){
-				$instance->save($player, PlayerWorldData::fromPlayer($player), false, PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT);
+				$instance->save($player, PlayerWorldData::fromPlayer($player), PerWorldPlayerDataSaveEvent::CAUSE_PLAYER_QUIT);
 			}
 		}
 

--- a/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/WorldManager.php
@@ -30,6 +30,9 @@ final class WorldManager{
 	/** @var TaskScheduler */
 	private $scheduler;
 
+	/** @var \Logger */
+	private $logger;
+
 	/** @var WorldInstance[] */
 	private $worlds = [];
 
@@ -37,6 +40,7 @@ final class WorldManager{
 		$this->bundle = new BundleManager($plugin->getConfig()->get("Bundled-Worlds"));
 		$this->database = WorldDatabaseFactory::create($plugin);
 		$this->player_manager = $plugin->getPlayerManager();
+		$this->logger = $plugin->getLogger();
 		$this->scheduler = $plugin->getScheduler();
 		$plugin->getServer()->getPluginManager()->registerEvents(new WorldListener($this), $plugin);
 	}
@@ -53,7 +57,7 @@ final class WorldManager{
 	}
 
 	public function onWorldLoad(Level $world) : void{
-		$this->worlds[$world->getId()] = new WorldInstance($world, $this->database, $this->player_manager, $this->bundle->getBundle($world->getFolderName()));
+		$this->worlds[$world->getId()] = new WorldInstance($world, $this->database, $this->player_manager, $this->logger, $this->bundle->getBundle($world->getFolderName()));
 	}
 
 	public function onWorldUnload(Level $world, bool $instant = false) : void{

--- a/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
@@ -63,7 +63,7 @@ abstract class LibasynqlWorldDatabase implements WorldDatabase{
 		});
 	}
 
-	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, bool $quit) : void{
+	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause) : void{
 		$this->database->executeInsert(WorldDatabaseStmts::SAVE, [
 			"id" => $this->saveBinaryString(self::createIdentifier($player, $world)),
 			"armor_inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->armor_inventory)),

--- a/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
@@ -76,7 +76,9 @@ abstract class LibasynqlWorldDatabase implements WorldDatabase{
 			"food" => $data->food,
 			"exhaustion" => $data->exhaustion,
 			"saturation" => $data->saturation
-		]);
+		], function(int $insertId, int $affectedRows) use($world, $player) : void{
+			$player->getServer()->getLogger()->debug("Player world data successfully saved for player {$player->getName()} in {$world->getName()}.");
+		});
 	}
 
 	abstract protected function fetchBinaryString(string $string) : string;

--- a/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/database/LibasynqlWorldDatabase.php
@@ -11,6 +11,7 @@ use Closure;
 use pocketmine\Player;
 use poggit\libasynql\DataConnector;
 use poggit\libasynql\libasynql;
+use poggit\libasynql\SqlError;
 
 abstract class LibasynqlWorldDatabase implements WorldDatabase{
 
@@ -63,22 +64,29 @@ abstract class LibasynqlWorldDatabase implements WorldDatabase{
 		});
 	}
 
-	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause) : void{
-		$this->database->executeInsert(WorldDatabaseStmts::SAVE, [
-			"id" => $this->saveBinaryString(self::createIdentifier($player, $world)),
-			"armor_inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->armor_inventory)),
-			"inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->inventory)),
-			"ender_inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->ender_inventory)),
-			"health" => $data->health,
-			"effects" => $this->saveBinaryString(WorldDatabaseUtils::serializeEffects($data->effects)),
-			"gamemode" => $data->gamemode,
-			"experience" => $data->experience,
-			"food" => $data->food,
-			"exhaustion" => $data->exhaustion,
-			"saturation" => $data->saturation
-		], function(int $insertId, int $affectedRows) use($world, $player) : void{
-			$player->getServer()->getLogger()->debug("Player world data successfully saved for player {$player->getName()} in {$world->getName()}.");
-		});
+	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause, Closure $onSave) : void{
+		$this->database->executeInsert(
+			WorldDatabaseStmts::SAVE,
+			[
+				"id" => $this->saveBinaryString(self::createIdentifier($player, $world)),
+				"armor_inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->armor_inventory)),
+				"inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->inventory)),
+				"ender_inventory" => $this->saveBinaryString(WorldDatabaseUtils::serializeInventoryContents($data->ender_inventory)),
+				"health" => $data->health,
+				"effects" => $this->saveBinaryString(WorldDatabaseUtils::serializeEffects($data->effects)),
+				"gamemode" => $data->gamemode,
+				"experience" => $data->experience,
+				"food" => $data->food,
+				"exhaustion" => $data->exhaustion,
+				"saturation" => $data->saturation
+			],
+			function(int $insertId, int $affectedRows) use($onSave) : void{
+				$onSave($affectedRows > 0);
+			},
+			function(SqlError $error) use($onSave) : void{
+				$onSave(false);
+			}
+		);
 	}
 
 	abstract protected function fetchBinaryString(string $string) : string;

--- a/src/BlockHorizons/PerWorldPlayer/world/database/WorldDatabase.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/database/WorldDatabase.php
@@ -28,8 +28,10 @@ interface WorldDatabase{
 	 * @param Player $player
 	 * @param PlayerWorldData $data
 	 * @param int $cause what triggered the save.
+	 * @param Closure $onSave
+	 * @phpstan-param Closure(bool $success) : void $onSave
 	 */
-	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause) : void;
+	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause, Closure $onSave) : void;
 
 	/**
 	 * Called when plugin disables to close any open resources and other stuff.

--- a/src/BlockHorizons/PerWorldPlayer/world/database/WorldDatabase.php
+++ b/src/BlockHorizons/PerWorldPlayer/world/database/WorldDatabase.php
@@ -27,9 +27,9 @@ interface WorldDatabase{
 	 * @param WorldInstance $world
 	 * @param Player $player
 	 * @param PlayerWorldData $data
-	 * @param bool $quit whether the player quit the server.
+	 * @param int $cause what triggered the save.
 	 */
-	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, bool $quit) : void;
+	public function save(WorldInstance $world, Player $player, PlayerWorldData $data, int $cause) : void;
 
 	/**
 	 * Called when plugin disables to close any open resources and other stuff.


### PR DESCRIPTION
## Introduction
This PR adds two cancellable events, one for data injection and one for data saving.

## Changes
### PerWorldPlayerDataInjectEvent
This event is called whenever a player joins the server or switches world, before data injection happens.
Other plugins can change whatever data is going to injected in the player or cancel the event to prevent the injection from happening at all.
I chose not to give a way for plugins to enforce data injection if the origin and the target worlds are in the same bundle or if the player has got the `per-world-player.bypass` permission to avoid useless queries to the database.

### PerWorldPlayerDataSaveEvent
This event is called when a player quits the server or switches world, before data saving happens (so it's called before PerWorldPlayerDataInjectEvent).
Other plugins, also in this case, can change whatever data is going to be saved or cancel event to completely prevent data saving.
If the player has the `per-world-player.bypass` permission, the event will be called anyway but it will cancelled by default so that other plugins can still enforce data injection in some situations.
Currently, this implementation has got one issue, that is, there is no way for plugins to enforce data injection if the origin and target worlds are in the same bundle. This is because the two checks are in two different functions and I was not sure how to handle the situation, so I'm open to suggestions.

### Minor changes
I added two debug messages, one after a data save is complete and the other when data save is cancelled so that plugin developers can understand if what happens it's actually what they wanted to achieve.
