### PR TITLE
Update libasyncql for PHP 8.1 support

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -7,5 +7,5 @@ projects:
     path: ""
     libs:
       - src: poggit/libasynql/libasynql
-        version: ^4.0.1
+        version: ^4.1.6
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: PerWorldPlayer
 main: BlockHorizons\PerWorldPlayer\Loader
 api: 4.0.1
-version: 0.4.5
+version: 0.4.6
 
 permissions:
   per-world-player.bypass:


### PR DESCRIPTION
A newer version of libasyncql is required for the plugin to be compatible with future versions